### PR TITLE
Show 'FINISH WORKOUT' button on last station

### DIFF
--- a/src/FamilyFitness.Blazor/Components/Pages/RunWod.razor
+++ b/src/FamilyFitness.Blazor/Components/Pages/RunWod.razor
@@ -113,7 +113,7 @@
                     <button class="btn btn-success btn-lg" 
                             @onclick="HandleSaveAndNextStation"
                             disabled="@(!cooldownComplete || savingScores)">
-                        @(savingScores ? "SAVING..." : "NEXT STATION")
+                        @(savingScores ? "SAVING..." : (currentRound == TotalRounds && currentStation == StationsPerRound ? "FINISH WORKOUT" : "NEXT STATION"))
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
## Changes

Updated the button label logic in RunWod.razor to display "FINISH WORKOUT" instead of "NEXT STATION" when the user is on the last station of the last round.

### Details
- Modified the button text conditional to check if `currentRound == TotalRounds && currentStation == StationsPerRound`
- Maintains existing "SAVING..." state during score submission
- Improves UX by giving clearer feedback about workout completion